### PR TITLE
chore: allow CI stack event reads

### DIFF
--- a/lib/substack-github-deploy-role-stack.ts
+++ b/lib/substack-github-deploy-role-stack.ts
@@ -41,6 +41,7 @@ export class SubstackGithubDeployRoleStack extends cdk.Stack {
         actions: [
           "cloudformation:CreateStack",
           "cloudformation:UpdateStack",
+          "cloudformation:DescribeStackEvents",
           "cloudformation:DescribeStacks",
           "cloudformation:GetTemplate",
           "cloudformation:DescribeStackResources",


### PR DESCRIPTION
## Summary
- allow the GitHub deploy role to read CloudFormation stack events during CDK deploys